### PR TITLE
Set up build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# Output (binary) directory
+out/
+
+# VS Code internal
+/.vscode

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,41 @@
+# Developer setup instructions:
+
+## Pre-requisites
+1. Download and install VS Code: https://code.visualstudio.com/download
+2. Install cmake: https://cmake.org/download/
+3. Install vcpkg: https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-cmd
+
+For ease of development, I recommend enabling the following extensions in VS Code-
+1. C++ extensions: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack
+2. CMake extension: https://marketplace.visualstudio.com/items?itemName=twxs.cmake
+3. VCPkg extension: https://marketplace.visualstudio.com/items?itemName=JackBoosY.vcpkg-cmake-tools
+
+## Development
+1. Go to the spf-21y folder-
+```
+cd tas_powertek/spf-21y
+```
+
+2. Download all cmake dependencies
+```
+cmake --preset=default
+```
+This should result in an output like-
+```
+...
+-- Configuring done (17.5s)
+-- Generating done (0.0s)
+-- Build files have been written to: /Users/mogre/github/TAS_Powertek/tas_powertek/spf-21y/out
+```
+
+3. Build the code-
+```
+cmake --build out
+```
+
+## Run Tests
+From the spf-21y directory, run-
+```
+cmake --build out && out/Tests
+```
+

--- a/tas_powertek/spf-21y/CMakeLists.txt
+++ b/tas_powertek/spf-21y/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(spf21y)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+add_compile_options(-Wall -Wextra -Wpedantic -Wswitch-enum)
+
+find_package(fmt CONFIG REQUIRED)
+find_package(glog CONFIG REQUIRED)
+find_package(gtest CONFIG REQUIRED)
+find_package(folly CONFIG REQUIRED)
+
+add_library(spf21y Enums.cpp)
+target_include_directories(spf21y PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR})
+
+# Testing
+enable_testing()
+add_executable(Tests test/EnumTest.cpp)
+add_definitions(-DGLOG_NO_EXPORT)
+target_link_libraries(Tests spf21y GTest::gtest_main glog::glog Folly::folly)
+include (GoogleTest)
+gtest_discover_tests(Tests)
+
+#target_include_directories(spf21y )
+#target_link_libraries(HelloWorld PRIVATE fmt::fmt)

--- a/tas_powertek/spf-21y/CMakePresets.json
+++ b/tas_powertek/spf-21y/CMakePresets.json
@@ -1,0 +1,13 @@
+{
+    "version": 2,
+    "configurePresets": [
+      {
+        "name": "default",
+        "generator": "Ninja",
+        "binaryDir": "${sourceDir}/out",
+        "cacheVariables": {
+          "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        }
+      }
+    ]
+  }

--- a/tas_powertek/spf-21y/Enums.cpp
+++ b/tas_powertek/spf-21y/Enums.cpp
@@ -1,0 +1,22 @@
+#include "Enums.h"
+
+namespace tas_powertek::spf21y { 
+
+template <>
+std::string_view toString(DataType dataType) {
+  switch (dataType) {
+    case DataType::FAULT:
+      return "Fault/Event";
+    case DataType::INTERVAL:
+      return "Interval";
+    case DataType::DAILY:
+      return "Daily";
+    case DataType::USER_SETTINGS:
+      return "User Settings";
+    case DataType::REAL_TIME:
+      return "Real Time";
+    case DataType::UNKNOWN:
+      return "(Error) Unknown";
+  }
+}
+}

--- a/tas_powertek/spf-21y/Enums.h
+++ b/tas_powertek/spf-21y/Enums.h
@@ -1,0 +1,21 @@
+
+#include <type_traits>
+#include <string_view>
+
+namespace tas_powertek::spf21y {
+enum class DataType {
+  UNKNOWN = 0,
+  FAULT,
+  INTERVAL,
+  DAILY,
+  USER_SETTINGS,
+  REAL_TIME,
+};
+
+template <typename T>
+requires(std::is_enum_v<T>)
+std::string_view toString(T enumVal);
+
+template <>
+std::string_view toString(DataType datatype);
+} // namespace tas_powertek::spf21y

--- a/tas_powertek/spf-21y/test/EnumTest.cpp
+++ b/tas_powertek/spf-21y/test/EnumTest.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include <folly/logging/xlog.h>
+
+#include "../Enums.h"
+
+namespace tas_powertek::spf21y {
+
+TEST(EnumTest, toString) {
+  EXPECT_EQ("Fault/Event", toString(DataType::FAULT));
+  EXPECT_EQ("Interval", toString(DataType::INTERVAL));
+  EXPECT_EQ("Daily", toString(DataType::DAILY));
+  EXPECT_EQ("User Settings", toString(DataType::USER_SETTINGS));
+  EXPECT_EQ("Real Time", toString(DataType::REAL_TIME));
+  XLOGF(INFO, "Successfully tested {}", "EnumTest");
+}
+}

--- a/tas_powertek/spf-21y/vcpkg-configuration.json
+++ b/tas_powertek/spf-21y/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "c3273867b07bf3ecc70b98c31e912b0e41d97200",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/tas_powertek/spf-21y/vcpkg.json
+++ b/tas_powertek/spf-21y/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": [
+    "fmt",
+    "folly",
+    "gtest",
+    "glog"
+  ]
+}


### PR DESCRIPTION
PROBLEM
We need a way to build the C++ code.

SOLUTION
Use:
1. CMake for defining build rules: Since this is the most common tooling used for C++ projects
2. VCPkg for defining dependencies, and using it to import: (a) GoogleTest for creating unit tests, (b) Folly for bunch of common functionality including coro support, (c) Fmt: For creating pretty logs

Created a simple `Enums` file and a google test that accompanies it as proof-of-concept