### PR TITLE
Added checksum computation

### DIFF
--- a/tas_powertek/spf-21y/CMakeLists.txt
+++ b/tas_powertek/spf-21y/CMakeLists.txt
@@ -13,15 +13,16 @@ find_package(gtest CONFIG REQUIRED)
 find_package(folly CONFIG REQUIRED)
 
 add_library(spf21y Enums.cpp Record.cpp)
+target_link_libraries(spf21y glog::glog Folly::folly)
 target_include_directories(spf21y PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR})
 
 # Testing
 enable_testing()
-add_executable(Tests test/EnumTest.cpp test/RecordTest.cpp)
+add_executable(Tests 
+    test/CheckSumTest.cpp
+    test/EnumTest.cpp
+    test/RecordTest.cpp)
 add_definitions(-DGLOG_NO_EXPORT)
 target_link_libraries(Tests spf21y GTest::gtest_main glog::glog Folly::folly)
 include (GoogleTest)
 gtest_discover_tests(Tests)
-
-#target_include_directories(spf21y )
-#target_link_libraries(HelloWorld PRIVATE fmt::fmt)

--- a/tas_powertek/spf-21y/Enums.h
+++ b/tas_powertek/spf-21y/Enums.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <type_traits>
 #include <string_view>
+#include <type_traits>
 
 namespace tas_powertek::spf21y {
 enum class DataType {
@@ -13,9 +13,9 @@ enum class DataType {
 };
 
 template <typename T>
-requires(std::is_enum_v<T>)
+  requires(std::is_enum_v<T>)
 std::string_view toString(T enumVal);
 
 template <>
 std::string_view toString(DataType datatype);
-} // namespace tas_powertek::spf21y
+}  // namespace tas_powertek::spf21y

--- a/tas_powertek/spf-21y/Record.h
+++ b/tas_powertek/spf-21y/Record.h
@@ -5,11 +5,12 @@
 
 #include "Enums.h"
 #include "RecordData.h"
+#include "detail/CheckSum.h"
 
 namespace tas_powertek::spf21y {
 
-using TimePoint = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
-using CheckSum = uint16_t;
+using TimePoint =
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
 
 class Record {
  public:
@@ -34,10 +35,10 @@ class Record {
   const RecordData& data() const;
 
   template <typename T>
-  requires std::derived_from<T, RecordData>
+    requires std::derived_from<T, RecordData>
   const T& data() const;
 
-  CheckSum checksum() const;
+  detail::CheckSum16 checksum() const;
 
  private:
   bool isValid_ = false;
@@ -50,7 +51,7 @@ class Record {
   TimePoint timestamp_;
 
   std::unique_ptr<RecordData> data_;
-  CheckSum checksum_;
+  detail::CheckSum16 checksum_;
 };
 
-}
+}  // namespace tas_powertek::spf21y

--- a/tas_powertek/spf-21y/RecordData.h
+++ b/tas_powertek/spf-21y/RecordData.h
@@ -6,4 +6,4 @@ class RecordData {
  public:
   virtual ~RecordData() = default;
 };
-}
+}  // namespace tas_powertek::spf21y

--- a/tas_powertek/spf-21y/detail/CheckSum.h
+++ b/tas_powertek/spf-21y/detail/CheckSum.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <numeric>
+#include <string_view>
+
+#include "folly/logging/xlog.h"
+
+namespace tas_powertek::spf21y::detail {
+
+template <typename TUnderlying>
+  requires std::unsigned_integral<TUnderlying>
+class CheckSum {
+ public:
+  explicit CheckSum(TUnderlying underlying) : underlying_(underlying) {}
+  CheckSum(const CheckSum&) = delete;
+  CheckSum(CheckSum&&) noexcept = default;
+  CheckSum& operator=(const CheckSum&) = delete;
+  CheckSum& operator=(CheckSum&&) noexcept = default;
+  ~CheckSum() = default;
+
+  static inline CheckSum compute(std::string_view data) {
+    TUnderlying sum = std::accumulate(data.begin(), data.end(), TUnderlying{});
+    return CheckSum(TUnderlying{} - sum);
+  }
+  TUnderlying underlying() const { return underlying_; }
+  bool verify(std::string_view data) {
+    TUnderlying sum = std::accumulate(data.begin(), data.end(), TUnderlying{});
+    return static_cast<TUnderlying>(underlying_ + sum) == TUnderlying{};
+  }
+
+ private:
+  TUnderlying underlying_;
+};
+
+using CheckSum16 = CheckSum<uint16_t>;
+}  // namespace tas_powertek::spf21y::detail

--- a/tas_powertek/spf-21y/test/CheckSumTest.cpp
+++ b/tas_powertek/spf-21y/test/CheckSumTest.cpp
@@ -1,0 +1,13 @@
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+
+#include "../detail/CheckSum.h"
+
+namespace tas_powertek::spf21y::detail {
+
+TEST(CheckSumTest, xlsCalculation) {
+  CheckSum16 checksum = CheckSum16::compute("\x74\x61\x73\x20\x31\x32\x35");
+  EXPECT_EQ(checksum.underlying(), uint16_t(0xFE00));
+  EXPECT_TRUE(checksum.verify("\x74\x61\x73\x20\x31\x32\x35"));
+}
+}  // namespace tas_powertek::spf21y::detail

--- a/tas_powertek/spf-21y/test/EnumTest.cpp
+++ b/tas_powertek/spf-21y/test/EnumTest.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
 
 #include "../Enums.h"
 
@@ -13,4 +13,4 @@ TEST(EnumTest, toString) {
   EXPECT_EQ("Real Time", toString(DataType::REAL_TIME));
   XLOGF(INFO, "Successfully tested {}", "EnumTest");
 }
-}
+}  // namespace tas_powertek::spf21y

--- a/tas_powertek/spf-21y/test/RecordTest.cpp
+++ b/tas_powertek/spf-21y/test/RecordTest.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
 
 #include "../Record.h"
 
@@ -11,6 +11,5 @@ TEST(RecordTest, toString) {
   EXPECT_EQ("Daily", toString(DataType::DAILY));
   EXPECT_EQ("User Settings", toString(DataType::USER_SETTINGS));
   EXPECT_EQ("Real Time", toString(DataType::REAL_TIME));
-  XLOGF(INFO, "Successfully tested {}", "EnumTest");
 }
-}
+}  // namespace tas_powertek::spf21y


### PR DESCRIPTION
PROBLEM
Checksum is used within the SPF21Y HTTP Post request/responses. This is different from CRC16; instead it is detailed in the spec sheet.

SOLUTION
Created a checksum computation / validation helper